### PR TITLE
fix: remove multiple script tags from slides html

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -164,7 +164,6 @@
 
 	<div class="progress"></div>
 
-	<script src="shower/shower.min.js"></script>
 	<script src="https://wptrainingteam.github.io/shower/shower.min.js"></script>
 	<!-- Copyright © 2018 Yours Truly, Famous Inc. -->
 	<!-- MIT License -->


### PR DESCRIPTION
Inside slides/index.html there were multiple script tag pointing
to the same shower.min.js file. Since the repo itself doesn't
contain any file on its own and the assets are served from github
CDN, we can remove the reference to the local asset.

Fixes #19 	